### PR TITLE
build: Dockerfile improvements 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,11 +38,6 @@ ENV DEBIAN_FRONTEND=nonintercative
 RUN apt-get update \
     && apt-get install --no-install-recommends -y \
     curl \
-    build-essential \
-    python3.11-distutils \
-    python3-pip \
-    python3-setuptools \
-    python3-dev \
     libmariadb-dev-compat \
     && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -77,7 +77,13 @@ FROM runtime-base AS prod
 
 # Add the virtualenv from the build-prod stage into the runtime image
 COPY --from=build-prod /home/iceberg/iceberg_rest/.venv /home/iceberg/iceberg_rest/.venv
-ENV PATH="/home/iceberg/iceberg_rest/.venv/bin:$PATH" 
+ENV PATH="/home/iceberg/iceberg_rest/.venv/bin:$PATH"
+
+# Give the iceberg user ownership of the iceberg_rest directory
+RUN chown -R iceberg:iceberg /home/iceberg/iceberg_rest
+
+# Switch to iceberg user
+USER iceberg
 
 # Add the source code
 COPY pyproject.toml ./
@@ -86,12 +92,6 @@ COPY README.md README.md
 
 # Install the source package
 RUN pip install . --no-deps
-
-# Give the iceberg user ownership of the iceberg_rest directory
-RUN chown -R iceberg:iceberg /home/iceberg/iceberg_rest
-
-# Switch to iceberg user
-USER iceberg
 
 # Serve the app in production mode
 CMD ["uvicorn", "src.iceberg_rest.main:app", "--host", "0.0.0.0", "--port", "8000"]
@@ -118,6 +118,12 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 COPY --from=build-dev /home/iceberg/iceberg_rest/.venv /home/iceberg/iceberg_rest/.venv
 ENV PATH="/home/iceberg/iceberg_rest/.venv/bin:$PATH"
 
+# Give the iceberg user ownership of the iceberg_rest directory
+RUN chown -R iceberg:iceberg /home/iceberg/iceberg_rest
+
+# Switch to iceberg user
+USER iceberg
+
 # Add the source code
 COPY pyproject.toml poetry.lock poetry.toml ./
 COPY src/ src/
@@ -126,12 +132,6 @@ COPY README.md README.md
 
 # Install the source package
 RUN pip install . --no-deps
-
-# Give the iceberg user ownership of the iceberg_rest directory
-RUN chown -R iceberg:iceberg /home/iceberg/iceberg_rest
-
-# Switch to iceberg user
-USER iceberg
 
 # Serve the app in development mode
 CMD ["uvicorn", "src.iceberg_rest.main:app", "--host",  "0.0.0.0", "--port", "8000", "--reload"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -98,7 +98,7 @@ CMD ["uvicorn", "src.iceberg_rest.main:app", "--host", "0.0.0.0", "--port", "800
 
 # Healthcheck
 HEALTHCHECK --interval=5m --timeout=30s --start-period=30s --retries=5 \
-    CMD curl -f  http://localhost:8000/healthcheck/healthcheck || exit 1
+    CMD curl -f  http://localhost:8000/v1/config || exit 1
 
 ########################################################################################
 


### PR DESCRIPTION
- Remove duplicate python installation.
- Fix default healthcheck endpoint. Default is now `http://localhost:8000/v1/config`.
- Change ownership of the `iceberg_rest` working directory before installing the source code into the virtualenv located there. This improves the build caching behavior in the event of a rebuild with only source code changes and no dependency changes.